### PR TITLE
Fix clustering eigen

### DIFF
--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -7,6 +7,7 @@ lhotse>=1.31.1
 # Align with upstream PyTorch requirements
 librosa>=0.10.1
 marshmallow
+megatron-core
 optuna
 packaging
 pyannote.core


### PR DESCRIPTION
In some cases offline diarization crashes with the next error:

_RuntimeError: false INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/native/BatchLinearAlgebra.cpp":1601, please report a bug to PyTorch. linalg.eigh: Argument 8 has illegal value. Most certainly there is a bug in the implementation calling the backend library._

I noticed this happens with torch 2.6 but doesn't happen with torch 2.3.

This is a fix to avoid this error, making sure that the input matrix for the eigen decomposition has the right shape. 

Also adding megatron-core dependency 